### PR TITLE
Allow reattaching in-progress fragments

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
 	"globals": {
+		"self": true,
 		"steal": true,
 		"can": true,
 		"Zepto": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ node_js: node
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: "54.0"

--- a/done-ssr-incremental-rendering-client.js
+++ b/done-ssr-incremental-rendering-client.js
@@ -1,6 +1,9 @@
 var apply = require("dom-patch/apply");
+var createAttacher = require("./reattach");
 
 var streamurl = document.currentScript.dataset.streamurl;
+var att = createAttacher();
+
 function render(instruction){
 	apply(document, instruction);
 }
@@ -15,6 +18,11 @@ fetch(streamurl, {
 		return reader.read().then(function(result){
 			var resultValue = result.value || new Uint8Array();
 			var chunk = decoder.decode(resultValue);
+
+			// If already attached stop reading
+			if(att.attached) {
+				return;
+			}
 
 			chunk.split("\n")
 			.filter(function(str) { return str.length; })
@@ -35,3 +43,5 @@ fetch(streamurl, {
 		console.error(err);
 	});
 });
+
+self.doneSsrAttach = att.doneSsrAttach;

--- a/index.html
+++ b/index.html
@@ -1,4 +1,0 @@
-<!doctype html>
-<html lang="en">
-
-<script src="./node_modules/steal/steal.js"></script>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "version": "git commit -am \"Update version number\" && git checkout -b release && git add -f dist/",
     "postpublish": "git push --tags && git checkout master && git branch -D release && git push",
     "testee": "testee test/test.html --browsers firefox",
-    "test": "npm run jshint && npm run testee",
+    "test": "npm run jshint && node build && npm run testee",
     "jshint": "jshint ./*.js --config",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",

--- a/reattach.js
+++ b/reattach.js
@@ -22,6 +22,8 @@ function createAttacher() {
 	}
 
 	function doneSsrAttach(fragment) {
+		var mo = new MutationObserver(checkCompleteness);
+
 		function checkCompleteness() {
 			var docDepth = depth(document);
 			var fragDepth = depth(fragment);
@@ -45,7 +47,6 @@ function createAttacher() {
 			}
 		}
 
-		var mo = new MutationObserver(checkCompleteness);
 		mo.observe(fragment, {childList: true, subtree: true});
 	}
 

--- a/reattach.js
+++ b/reattach.js
@@ -27,7 +27,13 @@ function createAttacher() {
 			var fragDepth = depth(fragment);
 
 			// Update whether or not attachment is complete
-			attacher.attached = docDepth <= fragDepth;
+			// if the fragment no longer has children, it means done-autorender
+			// Has already done the swap.
+			if(!fragment.firstChild) {
+				attacher.attached = true;
+			} else {
+				attacher.attached = docDepth <= fragDepth;
+			}
 
 			if(attacher.attached) {
 				mo.disconnect();

--- a/reattach.js
+++ b/reattach.js
@@ -1,0 +1,77 @@
+module.exports = createAttacher;
+
+function createAttacher() {
+	var attacher = Object.create(null);
+	attacher.attached = false;
+	attacher.doneSsrAttach = doneSsrAttach;
+
+	// Get the depth of a Node
+	function depth(root) {
+		var i = 0;
+		var walker = document.createTreeWalker(root, 0xFFFFFFFF, {
+			acceptNode: function(node){
+				var nt = node.nodeType;
+				return nt === 1 || nt === 3;
+			}
+		});
+
+		while(walker.nextNode()) {
+			i++;
+		}
+		return i;
+	}
+
+	function doneSsrAttach(fragment) {
+		function checkCompleteness() {
+			var docDepth = depth(document);
+			var fragDepth = depth(fragment);
+
+			// Update whether or not attachment is complete
+			attacher.attached = docDepth <= fragDepth;
+
+			if(attacher.attached) {
+				mo.disconnect();
+				// reattach now
+				if(fragment.firstChild) {
+					swap(document.head, fragment.querySelector("head"));
+					swap(document.body, fragment.querySelector("body"));
+				}
+			}
+		}
+
+		var mo = new MutationObserver(checkCompleteness);
+		mo.observe(fragment, {childList: true, subtree: true});
+	}
+
+	function isScriptOrStyle(node) {
+		var nn = node.nodeName;
+		return nn && (nn === "SCRIPT" || nn === "STYLE" || (nn === "LINK" && nn.rel === "stylesheet"));
+	}
+
+	function swap(parent, newParent) {
+		if(!newParent) {
+			return;
+		}
+
+		function loop(parent, cb) {
+			var child = parent.firstChild, next;
+			while(child) {
+				next = child.nextSibling;
+				if(!isScriptOrStyle(child)) {
+					cb(child);
+				}
+				child = next;
+			}
+		}
+
+		loop(parent, function(child){
+			parent.removeChild(child);
+		});
+
+		loop(newParent, function(child){
+			parent.appendChild(child);
+		});
+	}
+
+	return attacher;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -12,3 +12,13 @@ QUnit.module("Basics", {
 QUnit.test("Works", function(){
   F("#testing").exists("The instruction was added");
 });
+
+QUnit.module("doneSsrAttach", {
+	setup: function(){
+		F.open("//tests/attach.html");
+	}
+});
+
+QUnit.test("Swaps a frament into the document", function(){
+	F("#testing").exists().text(/Testing/, "Updated to the autorendered content");
+});

--- a/test/tests/attach.html
+++ b/test/tests/attach.html
@@ -1,0 +1,56 @@
+<!doctype html>
+
+<html lang="en">
+<head><title>Some Title</title>
+<body>
+	<script src="../helpers.js"></script>
+	<script>
+		testHelpers.mockFetch([[{
+			type: "insert",
+			route: "0.1", // The body
+			node: {
+				3: "DIV",
+				4: [["id","testing"]],
+				5: [{1:"Test"}]
+			}
+		}]]);
+	</script>
+
+	<script src="../../dist/global/done-ssr-incremental-rendering-client.js"
+		data-streamurl="/done-ssr-instr-1"></script>
+	<script>
+	(function(){
+		var cel = document.createElement.bind(document);
+		var ctn = document.createTextNode.bind(document);
+
+		var frag = document.createDocumentFragment();
+		doneSsrAttach(frag);
+
+		var head = cel("head");
+		var title = cel("title");
+		title.appendChild(ctn("Some Title"));
+		head.appendChild(title);
+		head.appendChild(ctn(""));
+
+		var body = cel("body");
+		for(var i = 0; i < 4; i++) {
+			var s = cel("script");
+			s.appendChild(ctn('"use strict";'));
+
+			body.appendChild(ctn(""));
+			body.appendChild(s);
+		}
+		var div = cel("div");
+		div.id = "testing";
+		div.appendChild(ctn("Testing"));
+		body.appendChild(div);
+
+		var html = cel("html");
+		html.appendChild(head);
+		html.appendChild(body);
+
+		frag.appendChild(html);
+	})();
+	</script>
+</body>
+</html>


### PR DESCRIPTION
This change allows for fragments that are still being modified to
replace the current document head and body. Using a MutationObserver, we
wait for the fragment to have the same number of Nodes as the document
and then swap it. This means that if there is a race between
done-autorender and incremental loading, we swap as soon as we can.

Closes #2