### PR TITLE
Assume reattachment happens within an iframe

### DIFF
--- a/done-ssr-incremental-rendering-client.js
+++ b/done-ssr-incremental-rendering-client.js
@@ -12,6 +12,13 @@ function render(instruction){
 	apply(document, instruction);
 }
 
+function removeSelf() {
+	var p = window.parent;
+	if(p.closeSsrIframe) {
+		p.closeSsrIframe();
+	}
+}
+
 fetch(streamurl, {
 	credentials: "same-origin"
 }).then(function(response){
@@ -48,4 +55,7 @@ fetch(streamurl, {
 	});
 });
 
-self.doneSsrAttach = att.doneSsrAttach;
+var doneSsrAttach = att.doneSsrAttach;
+
+// Start doing reattachment
+doneSsrAttach(window.parent.document.documentElement, removeSelf);

--- a/reattach.js
+++ b/reattach.js
@@ -25,7 +25,8 @@ function createAttacher() {
 		return document.documentElement.hasAttribute("data-attached");
 	}
 
-	function doneSsrAttach(fragment) {
+	function doneSsrAttach(fragment, callback) {
+		if(!callback) callback = Function.prototype;
 		var mo = new MutationObserver(checkCompleteness);
 
 		function checkCompleteness() {
@@ -41,44 +42,13 @@ function createAttacher() {
 				mo.disconnect();
 				// reattach now
 				if(!isAttached()) {
-					swap(document.head, fragment.querySelector("head"));
-					swap(document.body, fragment.querySelector("body"));
 					document.documentElement.setAttribute("data-attached", "");
+					callback();
 				}
 			}
 		}
 
 		mo.observe(fragment, {childList: true, subtree: true});
-	}
-
-	function isScriptOrStyle(node) {
-		var nn = node.nodeName;
-		return nn && (nn === "SCRIPT" || nn === "STYLE" || (nn === "LINK" && node.rel === "stylesheet"));
-	}
-
-	function swap(parent, newParent) {
-		if(!newParent) {
-			return;
-		}
-
-		function loop(parent, cb) {
-			var child = parent.firstChild, next;
-			while(child) {
-				next = child.nextSibling;
-				if(!isScriptOrStyle(child)) {
-					cb(child);
-				}
-				child = next;
-			}
-		}
-
-		loop(parent, function(child){
-			parent.removeChild(child);
-		});
-
-		loop(newParent, function(child){
-			parent.appendChild(child);
-		});
 	}
 
 	return attacher;

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ QUnit.module("Basics", {
 	}
 });
 
+
 QUnit.test("Works", function(){
   F("#testing").exists("The instruction was added");
 });

--- a/test/tests/attach-iframe.html
+++ b/test/tests/attach-iframe.html
@@ -1,0 +1,22 @@
+<!doctype html>
+
+<html lang="en">
+<head><title>Some Title</title>
+<body>
+	<script src="../helpers.js"></script>
+	<script>
+		testHelpers.mockFetch([[{
+			type: "insert",
+			route: "0.1", // The body
+			node: {
+				3: "DIV",
+				4: [["id","testing"]],
+				5: [{1:"Test"}]
+			}
+		}]]);
+	</script>
+
+	<script src="../../dist/global/done-ssr-incremental-rendering-client.js"
+		data-streamurl="/done-ssr-instr-1"></script>
+</body>
+</html>

--- a/test/tests/attach.html
+++ b/test/tests/attach.html
@@ -3,53 +3,20 @@
 <html lang="en">
 <head><title>Some Title</title>
 <body>
-	<script src="../helpers.js"></script>
-	<script>
-		testHelpers.mockFetch([[{
-			type: "insert",
-			route: "0.1", // The body
-			node: {
-				3: "DIV",
-				4: [["id","testing"]],
-				5: [{1:"Test"}]
-			}
-		}]]);
-	</script>
+	<iframe src="./attach-iframe.html"></iframe>
+	<script data-noop></script>
 
-	<script src="../../dist/global/done-ssr-incremental-rendering-client.js"
-		data-streamurl="/done-ssr-instr-1"></script>
+	<script data-noop></script>
+	<script data-noop></script>
 	<script>
 	(function(){
 		var cel = document.createElement.bind(document);
 		var ctn = document.createTextNode.bind(document);
 
-		var frag = document.createDocumentFragment();
-		doneSsrAttach(frag);
-
-		var head = cel("head");
-		var title = cel("title");
-		title.appendChild(ctn("Some Title"));
-		head.appendChild(title);
-		head.appendChild(ctn(""));
-
-		var body = cel("body");
-		for(var i = 0; i < 4; i++) {
-			var s = cel("script");
-			s.appendChild(ctn('"use strict";'));
-
-			body.appendChild(ctn(""));
-			body.appendChild(s);
-		}
 		var div = cel("div");
 		div.id = "testing";
 		div.appendChild(ctn("Testing"));
-		body.appendChild(div);
-
-		var html = cel("html");
-		html.appendChild(head);
-		html.appendChild(body);
-
-		frag.appendChild(html);
+		document.body.appendChild(div);
 	})();
 	</script>
 </body>


### PR DESCRIPTION
This changes the way the project works, so that it assumes that it is
being rendered within an iframe and calls
`window.parent.closeSsrIframe()` when it has finished.

This is an API breaking change.